### PR TITLE
add command line and env var substitution to templating

### DIFF
--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -168,6 +168,12 @@ def validate_host():
     default=const.DEFAULT_BACKEND_REGION,
     help="Region where terraform rootc/lock bucket exists",
 )
+@click.option(
+    "--config-var",
+    multiple=True,
+    default=[],
+    help='key=value to be supplied as jinja variables in config_file under "var" dictionary, can be specified multiple times',
+)
 @click.pass_context
 def cli(context, **kwargs):
     """CLI for the worker utility."""

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -294,7 +294,7 @@ class TerraformCommand(BaseCommand):
         if hook_script is None:
             raise HookError(f"hook script missing from {hook_dir}")
 
-        # populate environment with terraform vars
+        # populate environment with terraform remotes
         if os.path.isfile(f"{working_dir}/worker-locals.tf"):
             # I'm sorry. :-)
             r = re.compile(
@@ -322,7 +322,7 @@ class TerraformCommand(BaseCommand):
                             ).decode()
                         local_env[f"TF_REMOTE_{state}_{item}".upper()] = state_value
 
-        # populate environment with terraform remotes
+        # populate environment with terraform variables
         if os.path.isfile(f"{working_dir}/worker.auto.tfvars"):
             with open(f"{working_dir}/worker.auto.tfvars") as f:
                 for line in f:


### PR DESCRIPTION
This adds the command line option: --config-var  which requires a key=value argument, it can be passed multiple times.

This also adds all environment variables to be available as Jinja template vars, accessed as: env.VAR_NAME where 

VAR_NAME is the matching environment variable to use, this is used to simplify configuration in the modelfactory-infra repo once this is merged/released.

This will be cut as release 0.6.0 to PyPi once approved/merged.