### PR TITLE
[PLAT-10861] Add docker authentication to avoid rate-limiting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,70 +1,78 @@
 version: 2.1
 
 references:
-  platform-docker: &platform-cicd
+  platform-docker:
     docker:
-      - image: objectrocket/platform-cicd:latest
-        auth:
-          username: ${DOCKER_USERNAME}
-          password: ${DOCKER_PASSWORD}
+    - image: objectrocket/platform-cicd:latest
+      auth:
+        username: ${DOCKER_USERNAME}
+        password: ${DOCKER_PASSWORD}
 
+  context-to-use: &context-to-use
+    context: objectrocket-shared
+  objectrocket-docker-auth: &objectrocket-docker-auth
+    auth:
+      username: ${DOCKER_USERNAME}
+      password: ${DOCKER_PASSWORD}
 jobs:
   lint_and_test:
     docker:
-      - image: circleci/python:3.8
-        auth:
-          username: ${DOCKER_USERNAME}
-          password: ${DOCKER_PASSWORD}
+    - image: circleci/python:3.8
+      auth:
+        username: ${DOCKER_USERNAME}
+        password: ${DOCKER_PASSWORD}
 
     steps:
-      - checkout
-      - restore_cache:
-          key: deps-{{ checksum "poetry.lock" }}
-      - run:
-          name: Install dependencies
-          command: |
-            poetry install
-      - run:
-          name: Lint
-          command: |
-            make lint
-      - run:
-          name: Test
-          command: |
-            make test
-      - save_cache:
-          key: deps-{{ checksum "poetry.lock" }}
-          paths:
-            - /home/circleci/.cache/pypoetry/cache
-            - /home/circleci/.cache/pypoetry/virtualenvs
+    - checkout
+    - restore_cache:
+        key: deps-{{ checksum "poetry.lock" }}
+    - run:
+        name: Install dependencies
+        command: |
+          poetry install
+    - run:
+        name: Lint
+        command: |
+          make lint
+    - run:
+        name: Test
+        command: |
+          make test
+    - save_cache:
+        key: deps-{{ checksum "poetry.lock" }}
+        paths:
+        - /home/circleci/.cache/pypoetry/cache
+        - /home/circleci/.cache/pypoetry/virtualenvs
 
   build_deploy:
     docker:
-      - image: circleci/python:3.8
+    - <<: *objectrocket-docker-auth
+      image: circleci/python:3.8
     steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: docker login
-          command: |
-            docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
-            docker info
-      - run:
-          name: docker build and push
-          command: |
-            make OR_PYPI_PROD_PASSWORD="${OBJECTROCKET_PYPI_PASSWORD}" docker-build
-            make docker-deploy
+    - checkout
+    - setup_remote_docker
+    - run:
+        name: docker login
+        command: |
+          docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+          docker info
+    - run:
+        name: docker build and push
+        command: |
+          make OR_PYPI_PROD_PASSWORD="${OBJECTROCKET_PYPI_PASSWORD}" docker-build
+          make docker-deploy
 
 workflows:
   version: 2
   # runs on all untagged commits
   lint_and_test:
     jobs:
-      - lint_and_test:
-          filters:
-            tags:
-              ignore:
-                - /^[0-9]+.[0-9]+.[0-9]+$/
-                - /^[0-9]+.[0-9]+.[0-9]+rc[0-9]+$/
-            branches:
-              ignore: develop
+    - lint_and_test:
+        <<: *context-to-use
+        filters:
+          tags:
+            ignore:
+            - /^[0-9]+.[0-9]+.[0-9]+$/
+            - /^[0-9]+.[0-9]+.[0-9]+rc[0-9]+$/
+          branches:
+            ignore: develop


### PR DESCRIPTION

SUMMARY

FROM [PLAT-10861]
See: https://support.circleci.com/hc/en-us/articles/360050623311-Docker-Hub-rate-limiting-FAQ
Going forward best practice is to include docker authentication with all docker hub image pulls (even public images)

NOTE: This code change and PR was created through automation 
                            

[PLAT-10861]: https://objectrocket.atlassian.net/browse/PLAT-10861