### PR TITLE
Fix plugin path

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = boto3,click,jinja2,pytest,setuptools,tenacity,tfworker,yaml
+known_third_party = boto3,click,jinja2,pytest,pytest_lazyfixture,setuptools,tenacity,tfworker,yaml

--- a/poetry.lock
+++ b/poetry.lock
@@ -512,6 +512,17 @@ networkx = "*"
 pytest = ">=3"
 
 [[package]]
+name = "pytest-lazy-fixture"
+version = "0.6.3"
+description = "It helps to use fixtures in pytest.mark.parametrize"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pytest = ">=3.2.5"
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.1"
 description = "Extensions to the standard Python datetime module"
@@ -667,7 +678,7 @@ testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "1c4eec208c0f24bbdabe0b06e442a04efe0627b0ca3214d879ee20c5c0563d85"
+content-hash = "a48fdc60b90ab8847bcb331753ce5fa423a2502e86c6a46365ca66a00a37a432"
 
 [metadata.files]
 appdirs = [
@@ -891,6 +902,10 @@ pytest = [
 pytest-depends = [
     {file = "pytest-depends-1.0.1.tar.gz", hash = "sha256:90a28e2b87b75b18abd128c94015248544acac20e4392e9921e5a86f93319dfe"},
     {file = "pytest_depends-1.0.1-py3-none-any.whl", hash = "sha256:a1df072bcc93d77aca3f0946903f5fed8af2d9b0056db1dfc9ed5ac164ab0642"},
+]
+pytest-lazy-fixture = [
+    {file = "pytest-lazy-fixture-0.6.3.tar.gz", hash = "sha256:0e7d0c7f74ba33e6e80905e9bfd81f9d15ef9a790de97993e34213deb5ad10ac"},
+    {file = "pytest_lazy_fixture-0.6.3-py3-none-any.whl", hash = "sha256:e0b379f38299ff27a653f03eaa69b08a6fd4484e46fd1c9907d984b9f9daeda6"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ seed-isort-config = "^2.2.0"
 flake8 = "^3.8.3"
 wheel = "^0.35.1"
 pytest-depends = "^1.0.1"
+pytest-lazy-fixture = "^0.6.3"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -20,6 +20,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 from tfworker.commands.terraform import TerraformCommand
 
+
 # context manager to allow testing exceptions in parameterized tests
 @contextmanager
 def does_not_raise():
@@ -28,6 +29,7 @@ def does_not_raise():
 
 def mock_pipe_exec(args, stdin=None, cwd=None, env=None):
     return (0, "".encode(), "".encode())
+
 
 def mock_tf_version(args):
     return (0, args.encode(), "".encode())
@@ -101,16 +103,18 @@ class TestTerraformCommand:
         [
             ("Terraform v0.12.29", 12, 29, does_not_raise()),
             ("Terraform v0.13.5", 13, 5, does_not_raise()),
-            ("TF 14", "", "", pytest.raises(SystemExit))
-        ]
+            ("TF 14", "", "", pytest.raises(SystemExit)),
+        ],
     )
     def test_get_tf_version(self, stdout, major, minor, expected_exception):
         with mock.patch(
             "tfworker.commands.terraform.TerraformCommand.pipe_exec",
-            side_effect=mock_tf_version
+            side_effect=mock_tf_version,
         ) as mocked:
             with expected_exception:
-                (actual_major, actual_minor) = TerraformCommand.get_terraform_version(stdout)
+                (actual_major, actual_minor) = TerraformCommand.get_terraform_version(
+                    stdout
+                )
                 assert actual_major == major
                 assert actual_minor == minor
                 mocked.assert_called_once()

--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -13,17 +13,28 @@
 # limitations under the License.
 
 import filecmp
+from contextlib import contextmanager
 from unittest import mock
 
 import pytest
+from pytest_lazyfixture import lazy_fixture
 from tfworker.commands.terraform import TerraformCommand
+
+# context manager to allow testing exceptions in parameterized tests
+@contextmanager
+def does_not_raise():
+    yield
 
 
 def mock_pipe_exec(args, stdin=None, cwd=None, env=None):
     return (0, "".encode(), "".encode())
 
+def mock_tf_version(args):
+    return (0, args.encode(), "".encode())
+
 
 class TestTerraformCommand:
+    @pytest.mark.parametrize("tf_cmd", [lazy_fixture("tf_12cmd")])
     def test_prep_modules(self, tf_cmd, rootc):
         tf_cmd.prep_modules()
         for test_file in [
@@ -34,7 +45,17 @@ class TestTerraformCommand:
             dst = rootc.temp_dir + test_file
             assert filecmp.cmp(src, dst, shallow=False)
 
-    @pytest.mark.parametrize("method", ["init", "plan", "apply"])
+    @pytest.mark.parametrize(
+        "method, tf_cmd",
+        [
+            ("init", lazy_fixture("tf_12cmd")),
+            ("plan", lazy_fixture("tf_12cmd")),
+            ("apply", lazy_fixture("tf_12cmd")),
+            ("init", lazy_fixture("tf_13cmd")),
+            ("plan", lazy_fixture("tf_13cmd")),
+            ("apply", lazy_fixture("tf_13cmd")),
+        ],
+    )
     def test_run(self, tf_cmd, method):
         with mock.patch(
             "tfworker.commands.terraform.TerraformCommand.pipe_exec",
@@ -74,3 +95,22 @@ class TestTerraformCommand:
         assert return_exit_code == exit_code
         assert stdout.encode() in return_stdout.rstrip()
         assert return_stderr.rstrip() in stderr.encode()
+
+    @pytest.mark.parametrize(
+        "stdout, major, minor, expected_exception",
+        [
+            ("Terraform v0.12.29", 12, 29, does_not_raise()),
+            ("Terraform v0.13.5", 13, 5, does_not_raise()),
+            ("TF 14", "", "", pytest.raises(SystemExit))
+        ]
+    )
+    def test_get_tf_version(self, stdout, major, minor, expected_exception):
+        with mock.patch(
+            "tfworker.commands.terraform.TerraformCommand.pipe_exec",
+            side_effect=mock_tf_version
+        ) as mocked:
+            with expected_exception:
+                (actual_major, actual_minor) = TerraformCommand.get_terraform_version(stdout)
+                assert actual_major == major
+                assert actual_minor == minor
+                mocked.assert_called_once()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ import tfworker
 import tfworker.commands.base
 import tfworker.commands.root
 import tfworker.providers
+from pytest_lazyfixture import lazy_fixture
 
 
 @pytest.fixture
@@ -47,18 +48,50 @@ def rootc():
     return result
 
 
+@pytest.fixture(params=[lazy_fixture("tf_12cmd"), lazy_fixture("tf_13cmd"), lazy_fixture("tf_Xcmd")])
+def tf_cmd(request):
+    return request.param
+
+
 @pytest.fixture
 @mock.patch("tfworker.authenticators.aws.AWSAuthenticator.session")
 @mock.patch("tfworker.backends.s3.S3Backend.create_table")
 def basec(create_table, session, rootc):
     return tfworker.commands.base.BaseCommand(rootc, "test-0001")
 
+@pytest.fixture
+@mock.patch("tfworker.authenticators.aws.AWSAuthenticator.session")
+@mock.patch("tfworker.backends.s3.S3Backend.create_table")
+def tf_Xcmd(create_table, session, rootc):
+    return tfworker.commands.terraform.TerraformCommand(
+        rootc, deployment="test-0001"
+    )
 
 @pytest.fixture
 @mock.patch("tfworker.authenticators.aws.AWSAuthenticator.session")
 @mock.patch("tfworker.backends.s3.S3Backend.create_table")
-def tf_cmd(create_table, session, rootc):
-    return tfworker.commands.terraform.TerraformCommand(rootc, deployment="test-0001")
+def tf_13cmd(create_table, session, rootc):
+    return tfworker.commands.terraform.TerraformCommand(
+        rootc, deployment="test-0001", tf_version=(13, 5)
+    )
+
+
+@pytest.fixture
+@mock.patch("tfworker.authenticators.aws.AWSAuthenticator.session")
+@mock.patch("tfworker.backends.s3.S3Backend.create_table")
+def tf_12cmd(create_table, session, rootc):
+    return tfworker.commands.terraform.TerraformCommand(
+        rootc, deployment="test-0001", tf_version=(12, 27)
+    )
+
+
+@pytest.fixture
+@mock.patch("tfworker.authenticators.aws.AWSAuthenticator.session")
+@mock.patch("tfworker.backends.s3.S3Backend.create_table")
+def tf_13cmd(create_table, session, rootc):
+    return tfworker.commands.terraform.TerraformCommand(
+        rootc, deployment="test-0001", tf_version=(13, 5)
+    )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,9 @@ def rootc():
     return result
 
 
-@pytest.fixture(params=[lazy_fixture("tf_12cmd"), lazy_fixture("tf_13cmd"), lazy_fixture("tf_Xcmd")])
+@pytest.fixture(
+    params=[lazy_fixture("tf_12cmd"), lazy_fixture("tf_13cmd"), lazy_fixture("tf_Xcmd")]
+)
 def tf_cmd(request):
     return request.param
 
@@ -59,13 +61,13 @@ def tf_cmd(request):
 def basec(create_table, session, rootc):
     return tfworker.commands.base.BaseCommand(rootc, "test-0001")
 
+
 @pytest.fixture
 @mock.patch("tfworker.authenticators.aws.AWSAuthenticator.session")
 @mock.patch("tfworker.backends.s3.S3Backend.create_table")
 def tf_Xcmd(create_table, session, rootc):
-    return tfworker.commands.terraform.TerraformCommand(
-        rootc, deployment="test-0001"
-    )
+    return tfworker.commands.terraform.TerraformCommand(rootc, deployment="test-0001")
+
 
 @pytest.fixture
 @mock.patch("tfworker.authenticators.aws.AWSAuthenticator.session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,15 +88,6 @@ def tf_12cmd(create_table, session, rootc):
 
 
 @pytest.fixture
-@mock.patch("tfworker.authenticators.aws.AWSAuthenticator.session")
-@mock.patch("tfworker.backends.s3.S3Backend.create_table")
-def tf_13cmd(create_table, session, rootc):
-    return tfworker.commands.terraform.TerraformCommand(
-        rootc, deployment="test-0001", tf_version=(13, 5)
-    )
-
-
-@pytest.fixture
 def definition_odict():
     one_def = {
         "test": collections.OrderedDict(

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -74,7 +74,7 @@ class TestPlugins:
         )
         plugins.download()
         files = glob.glob(
-            f"{rootc.temp_dir}/terraform-plugins/{opsys}_{machine}/terraform-provider-null_v2.1.2*"
+            f"{rootc.temp_dir}/terraform-plugins/terraform-provider-null_v2.1.2*"
         )
         assert len(files) > 0
         for afile in files:

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -51,6 +51,14 @@ class TerraformCommand(BaseCommand):
         self._terraform_bin = kwargs.get("terraform_bin")
 
         self._plan_for = "destroy" if kwargs.get("destroy") else "apply"
+        (self._tf_version_major, self._tf_version_minor) = kwargs.get(
+            "tf_version", (None, None)
+        )
+        if self._tf_version_major is None or self._tf_version_minor is None:
+            (
+                self._tf_version_major,
+                self._tf_version_minor,
+            ) = self.get_terraform_version(self._terraform_bin)
         super(TerraformCommand, self).__init__(rootc, plan_for=self._plan_for, **kwargs)
 
     @property
@@ -149,12 +157,20 @@ class TerraformCommand(BaseCommand):
 
     def _run(self, definition, command, debug=False, plan_action="init"):
         """Run terraform."""
-        params = {
-            "init": f"-input=false -no-color -plugin-dir={self._temp_dir}/terraform-plugins",
-            "plan": "-input=false -detailed-exitcode -no-color",
-            "apply": "-input=false -no-color -auto-approve",
-            "destroy": "-input=false -no-color -force",
-        }
+        if self._tf_version_major == 12:
+            params = {
+                "init": f"-input=false -no-color -plugin-dir={self._temp_dir}/terraform-plugins",
+                "plan": "-input=false -detailed-exitcode -no-color",
+                "apply": "-input=false -no-color -auto-approve",
+                "destroy": "-input=false -no-color -force",
+            }
+        else:
+            params = {
+                "init": f"-input=false -no-color",
+                "plan": "-input=false -detailed-exitcode -no-color",
+                "apply": "-input=false -no-color -auto-approve",
+                "destroy": "-input=false -no-color -force",
+            }
 
         if plan_action == "destroy":
             params["plan"] += " -destroy"
@@ -479,3 +495,21 @@ class TerraformCommand(BaseCommand):
             )
         json_output = json.loads(stdout)
         return json.dumps(json_output, indent=None, separators=(",", ":"))
+
+    @staticmethod
+    def get_terraform_version(terraform_bin):
+        (return_code, stdout, stderr) = TerraformCommand.pipe_exec(f"{terraform_bin} version")
+        if return_code != 0:
+            click.secho(f"unable to get terraform version\n{stderr}", fg="red")
+            raise SystemExit(1)
+        version = stdout.decode("UTF-8").split("\n")[0]
+        version_search = re.search(r".* v\d+\.(\d+)\.(\d+)", version)
+        if version_search:
+            click.secho(
+                f"Terraform Version Result: {version}, using major:{version_search.group(1)}, minor:{version_search.group(2)}",
+                fg="yellow",
+            )
+            return (int(version_search.group(1)), int(version_search.group(2)))
+        else:
+            click.secho(f"unable to get terraform version\n{stderr}", fg="red")
+            raise SystemExit(1)

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -166,7 +166,7 @@ class TerraformCommand(BaseCommand):
             }
         else:
             params = {
-                "init": f"-input=false -no-color",
+                "init": "-input=false -no-color",
                 "plan": "-input=false -detailed-exitcode -no-color",
                 "apply": "-input=false -no-color -auto-approve",
                 "destroy": "-input=false -no-color -force",

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -498,7 +498,9 @@ class TerraformCommand(BaseCommand):
 
     @staticmethod
     def get_terraform_version(terraform_bin):
-        (return_code, stdout, stderr) = TerraformCommand.pipe_exec(f"{terraform_bin} version")
+        (return_code, stdout, stderr) = TerraformCommand.pipe_exec(
+            f"{terraform_bin} version"
+        )
         if return_code != 0:
             click.secho(f"unable to get terraform version\n{stderr}", fg="red")
             raise SystemExit(1)

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -150,7 +150,7 @@ class TerraformCommand(BaseCommand):
     def _run(self, definition, command, debug=False, plan_action="init"):
         """Run terraform."""
         params = {
-            "init": "-input=false -no-color",
+            "init": f"-input=false -no-color -plugin-dir={self._temp_dir}/terraform-plugins",
             "plan": "-input=false -detailed-exitcode -no-color",
             "apply": "-input=false -no-color -auto-approve",
             "destroy": "-input=false -no-color -force",

--- a/tfworker/plugins.py
+++ b/tfworker/plugins.py
@@ -88,7 +88,10 @@ class PluginsCollection(collections.abc.Mapping):
             files = glob.glob(f"{plugin_dir}/{_platform}/terraform-provider*")
             for afile in files:
                 os.chmod(afile, 0o755)
+                filename = os.path.basename(afile)
+                os.rename(afile, f"{plugin_dir}/{filename}")
 
+            click.secho(f"plugin installed to: {plugin_dir}/{_platform}/", fg="yellow")
 
 def get_url(name, details):
     """

--- a/tfworker/plugins.py
+++ b/tfworker/plugins.py
@@ -93,6 +93,7 @@ class PluginsCollection(collections.abc.Mapping):
 
             click.secho(f"plugin installed to: {plugin_dir}/{_platform}/", fg="yellow")
 
+
 def get_url(name, details):
     """
     Determine the URL for the plugin


### PR DESCRIPTION
fixes the plugin path issue for TF12, and paves the way for alternate handling of plugins in TF13. The terraform-worker-examples repo has working examples for TF13, but it's a little klunky.

Added tests around version handling, and expectations for running with both TF12 and TF13.