### PR TITLE
DA-1227: fix limits

### DIFF
--- a/tfworker/commands/base.py
+++ b/tfworker/commands/base.py
@@ -26,7 +26,7 @@ class BaseCommand:
         self,
         rootc,
         deployment="undefined",
-        limit=None,
+        limit=tuple(),
         plan_for="apply",
         tf_version_major=0,
         **kwargs

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -84,7 +84,13 @@ class TerraformCommand(BaseCommand):
         )
 
     def exec(self):
-        for definition in self.definitions.limited():
+        try:
+            def_iter = self.definitions.limited()
+        except ValueError as e:
+            click.secho(f"Error with supplied limit: {e}", fg="red")
+            raise SystemExit(1)
+
+        for definition in def_iter:
             execute = False
             # copy definition files / templates etc.
             click.secho(f"preparing definition: {definition.tag}", fg="green")

--- a/tfworker/definitions.py
+++ b/tfworker/definitions.py
@@ -243,13 +243,13 @@ class DefinitionsCollection(collections.abc.Mapping):
         if iter_size == 0:
             # a limit was supplied, but not matched, raise an error
             if self._limit:
-                raise ValueError("no items matching limit")
+                raise ValueError("no definitions matching --limit")
             # the run is not limited to anything, so return everything
             else:
                 return self.iter(honor_destroy=True)
         elif iter_size < self._limit_size:
             # not all limit items are matched
-            raise ValueError("not all items matching limit")
+            raise ValueError("not all definitions match --limit")
         else:
             return iter(filter(lambda d: d.limited, self.iter(honor_destroy=True)))
 

--- a/tfworker/definitions.py
+++ b/tfworker/definitions.py
@@ -201,6 +201,8 @@ class DefinitionsCollection(collections.abc.Mapping):
         self._body = definitions
         self._plan_for = plan_for
         self._definitions = collections.OrderedDict()
+        self._limit = True if len(limit) > 0 else False
+        self._limit_size = len(limit)
         for definition, body in definitions.items():
             self._definitions[definition] = Definition(
                 definition,
@@ -235,9 +237,19 @@ class DefinitionsCollection(collections.abc.Mapping):
 
     def limited(self):
         # handle the case where nothing is filtered
-        if len(list(filter(lambda d: d.limited, self.iter(honor_destroy=True)))) == 0:
+        iter_size = len(
+            list(filter(lambda d: d.limited, self.iter(honor_destroy=True)))
+        )
+        if iter_size == 0:
+            # a limit was supplied, but not matched, raise an error
+            if self._limit:
+                raise ValueError("no items matching limit")
             # the run is not limited to anything, so return everything
-            return self.iter(honor_destroy=True)
+            else:
+                return self.iter(honor_destroy=True)
+        elif iter_size < self._limit_size:
+            # not all limit items are matched
+            raise ValueError("not all items matching limit")
         else:
             return iter(filter(lambda d: d.limited, self.iter(honor_destroy=True)))
 


### PR DESCRIPTION
fix object type in base command, click will always provide an empty tuple when there is no --limit supplied

add knowledge to DefinitionCollection of expected limit size, and raise errors when the collection does not meet the criteria specified by any --limit parameters