### PR TITLE
add support for more complex terraform_vars

### DIFF
--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -29,6 +29,17 @@ terraform:
     ip_list:
       - 127.0.0.1/32
       - 192.168.0.1/32
+    map_list:
+      list:
+        - a
+        - b
+        - c
+    map_map:
+      map:
+        list:
+          - x
+          - y
+          - z 
   definitions:
     test:
       path: /definitions/test_a

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -117,19 +117,23 @@ class TestDefinitions:
         "base, expected, inner",
         [
             ("a_test_str", '"a_test_str"', False),
-            ({"key1": "val1", "key2": "val2"}, '{"key1": "val1", "key2": "val2"}', False),
+            (
+                {"key1": "val1", "key2": "val2"},
+                '{"key1": "val1", "key2": "val2"}',
+                False,
+            ),
             ({"key1": "val1", "key2": "val2"}, {"key1": "val1", "key2": "val2"}, True),
             (["item1", "item2", "item3"], '["item1", "item2", "item3"]', False),
             (["item1", "item2", "item3"], ["item1", "item2", "item3"], True),
             (
                 {"lkey": ["item1", "item2", "item3"]},
                 '{"lkey": ["item1", "item2", "item3"]}',
-                False
+                False,
             ),
             (
                 {"lkey": ["item1", "item2", "item3"]},
                 {"lkey": ["item1", "item2", "item3"]},
-                True
+                True,
             ),
         ],
     )

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -114,16 +114,24 @@ class TestDefinitions:
         assert test_vars["c"] == expected
 
     @pytest.mark.parametrize(
-        "base, expected",
+        "base, expected, inner",
         [
-            ("a_test_str", '"a_test_str"'),
-            ({"key1": "val1", "key2": "val2"}, '{"key1": "val1", "key2": "val2"}'),
-            (["item1", "item2", "item3"], '["item1", "item2", "item3"]'),
+            ("a_test_str", '"a_test_str"', False),
+            ({"key1": "val1", "key2": "val2"}, '{"key1": "val1", "key2": "val2"}', False),
+            ({"key1": "val1", "key2": "val2"}, {"key1": "val1", "key2": "val2"}, True),
+            (["item1", "item2", "item3"], '["item1", "item2", "item3"]', False),
+            (["item1", "item2", "item3"], ["item1", "item2", "item3"], True),
             (
                 {"lkey": ["item1", "item2", "item3"]},
                 '{"lkey": ["item1", "item2", "item3"]}',
+                False
+            ),
+            (
+                {"lkey": ["item1", "item2", "item3"]},
+                {"lkey": ["item1", "item2", "item3"]},
+                True
             ),
         ],
     )
-    def test_var_typer(self, base, expected):
-        assert Definition.vars_typer(base) == expected
+    def test_var_typer(self, base, expected, inner):
+        assert Definition.vars_typer(base, inner=inner) == expected

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -53,6 +53,8 @@ region = "us-west-2"
 deprecated_region = "us-west-2"
 domain = "test.domain.com"
 ip_list = ["127.0.0.1/32", "192.168.0.1/32"]
+map_list = {"list": ["a", "b", "c"]}
+map_map = {"map": {"list": ["x", "y", "z"]}}
 deployment = "test-0001"
 """
 
@@ -110,3 +112,18 @@ class TestDefinitions:
             base.get("terraform_vars"),
         )
         assert test_vars["c"] == expected
+
+    @pytest.mark.parametrize(
+        "base, expected",
+        [
+            ("a_test_str", '"a_test_str"'),
+            ({"key1": "val1", "key2": "val2"}, '{"key1": "val1", "key2": "val2"}'),
+            (["item1", "item2", "item3"], '["item1", "item2", "item3"]'),
+            (
+                {"lkey": ["item1", "item2", "item3"]},
+                '{"lkey": ["item1", "item2", "item3"]}',
+            ),
+        ],
+    )
+    def test_var_typer(self, base, expected):
+        assert Definition.vars_typer(base) == expected


### PR DESCRIPTION
added method to construct a terraform compatible variable structure. supports simple types bool, str, list, map, as well as complex types and objects (map(list(string)), map(object{....}) etc.,)


-- add tests to new variable function
-- update test fixtures with new supported types