### PR TITLE
DA-1601 Terraform 0.14 and 0.15 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,39 @@ providers:
     source: "gavinbunney/kubectl"
 ```
 
+**NOTE:** By default, terraform-worker emits all of the providers from the configuration in each
+definition's terraform.tf file.  If all of the providers are available from the default hashicorp
+namespaced, this behavior is fine.  However, when using a provider from a non-hashicorp namespace
+AND terraform 0.13+, definitions which do not explicitly define the `source` for the non-hashicorp
+provider will not be able to resolve the provider. As a stop-gap fix, support for a `provider_excludes`
+field has been added.  In the future, the terraform-worker will support auto-discovering each
+definitions `required_providers`.
+
+
+**provider_excludes** example:
+```yaml
+  providers:
+    'null':
+      vars:
+        version: "~> 2.1"
+    kubectl:
+      vars:
+        version: "~> 1.9"
+        source: "gavinbunney/kubectl"
+
+  definitions:
+    # Either setup a VPC and resources, or deploy into an existing one
+    network:
+      path: /definitions/aws/network-existing
+
+    database:
+      path: /definitions/aws/rds
+
+      provider_excludes:
+        - kubectl
+```
+
+
 ## Development
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -41,39 +41,6 @@ providers:
     source: "gavinbunney/kubectl"
 ```
 
-**NOTE:** By default, terraform-worker emits all of the providers from the configuration in each
-definition's terraform.tf file.  If all of the providers are available from the default hashicorp
-namespaced, this behavior is fine.  However, when using a provider from a non-hashicorp namespace
-AND terraform 0.13+, definitions which do not explicitly define the `source` for the non-hashicorp
-provider will not be able to resolve the provider. As a stop-gap fix, support for a `provider_excludes`
-field has been added.  In the future, the terraform-worker will support auto-discovering each
-definitions `required_providers`.
-
-
-**provider_excludes** example:
-```yaml
-  providers:
-    'null':
-      vars:
-        version: "~> 2.1"
-    kubectl:
-      vars:
-        version: "~> 1.9"
-        source: "gavinbunney/kubectl"
-
-  definitions:
-    # Either setup a VPC and resources, or deploy into an existing one
-    network:
-      path: /definitions/aws/network-existing
-
-    database:
-      path: /definitions/aws/rds
-
-      provider_excludes:
-        - kubectl
-```
-
-
 ## Development
 
 ```sh

--- a/poetry.lock
+++ b/poetry.lock
@@ -488,6 +488,18 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "lark-parser"
+version = "0.10.1"
+description = "a modern parsing library"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+nearley = ["js2py"]
+regex = ["regex"]
+
+[[package]]
 name = "markupsafe"
 version = "1.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -821,6 +833,17 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "python-hcl2"
+version = "2.0.3"
+description = "A parser for HCL2"
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.dependencies]
+lark-parser = ">=0.10.0,<0.11.0"
+
+[[package]]
 name = "pytz"
 version = "2021.1"
 description = "World timezone definitions, modern and historical"
@@ -1027,7 +1050,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "96bc683573533b9b6e4075307490a5cdc616bb6ce7825ce93d3d840a7fb039cb"
+content-hash = "91582848654dc39deeaf10091094395ad355a4997f3b1e642e038cf8f617fc1b"
 
 [metadata.files]
 appdirs = [
@@ -1308,6 +1331,9 @@ jmespath = [
     {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
     {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
 ]
+lark-parser = [
+    {file = "lark-parser-0.10.1.tar.gz", hash = "sha256:42f367612a1bbc4cf9d8c8eb1b209d8a9b397d55af75620c9e6f53e502235996"},
+]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
     {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"},
@@ -1490,6 +1516,9 @@ pytest-lazy-fixture = [
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+]
+python-hcl2 = [
+    {file = "python-hcl2-2.0.3.tar.gz", hash = "sha256:62bfe6a152e794700abd125bfb5c53913af8c8bc98eeef37bd30f87e3f19bfc2"},
 ]
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "terraform-worker"
-version = "0.10.0"
+version = "0.10.1-rc0"
 description = "An orchestration tool for Terraform"
 authors = ["Richard Maynard <richard.maynard@objectrocket.com>"]
 packages = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "terraform-worker"
-version = "0.10.1-rc0"
+version = "0.10.1"
 description = "An orchestration tool for Terraform"
 authors = ["Richard Maynard <richard.maynard@objectrocket.com>"]
 packages = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ tenacity = "^6.2.0"
 requests = "^2.25"
 google-cloud-storage = "^1.37.1"
 moto = {extras = ["sts"], version = "^2.0.5"}
+python-hcl2 = "^2.0.3"
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.18.1"

--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -72,17 +72,91 @@ class TestTerraformCommand:
                 assert filecmp.cmp(src, dst, shallow=False)
 
     @pytest.mark.parametrize(
-        "method, tf_cmd",
+        "method, tf_cmd, args",
         [
-            ("init", lazy_fixture("tf_12cmd")),
-            ("plan", lazy_fixture("tf_12cmd")),
-            ("apply", lazy_fixture("tf_12cmd")),
-            ("init", lazy_fixture("tf_13cmd")),
-            ("plan", lazy_fixture("tf_13cmd")),
-            ("apply", lazy_fixture("tf_13cmd")),
+            (
+                "init",
+                lazy_fixture("tf_12cmd"),
+                ["-input=false", "-no-color", "-plugin-dir"],
+            ),
+            (
+                "plan",
+                lazy_fixture("tf_12cmd"),
+                ["-input=false", "-detailed-exitcode", "-no-color"],
+            ),
+            (
+                "apply",
+                lazy_fixture("tf_12cmd"),
+                ["-input=false", "-no-color", "-auto-approve"],
+            ),
+            (
+                "destroy",
+                lazy_fixture("tf_12cmd"),
+                ["-input=false", "-no-color", "-force"],
+            ),
+            (
+                "init",
+                lazy_fixture("tf_13cmd"),
+                ["-input=false", "-no-color", "-plugin-dir"],
+            ),
+            (
+                "plan",
+                lazy_fixture("tf_13cmd"),
+                ["-input=false", "-detailed-exitcode", "-no-color"],
+            ),
+            (
+                "apply",
+                lazy_fixture("tf_13cmd"),
+                ["-input=false", "-no-color", "-auto-approve"],
+            ),
+            (
+                "destroy",
+                lazy_fixture("tf_13cmd"),
+                ["-input=false", "-no-color", "-force"],
+            ),
+            (
+                "init",
+                lazy_fixture("tf_14cmd"),
+                ["-input=false", "-no-color", "-plugin-dir"],
+            ),
+            (
+                "plan",
+                lazy_fixture("tf_14cmd"),
+                ["-input=false", "-detailed-exitcode", "-no-color"],
+            ),
+            (
+                "apply",
+                lazy_fixture("tf_14cmd"),
+                ["-input=false", "-no-color", "-auto-approve"],
+            ),
+            (
+                "destroy",
+                lazy_fixture("tf_14cmd"),
+                ["-input=false", "-no-color", "-force"],
+            ),
+            (
+                "init",
+                lazy_fixture("tf_15cmd"),
+                ["-input=false", "-no-color", "-plugin-dir"],
+            ),
+            (
+                "plan",
+                lazy_fixture("tf_15cmd"),
+                ["-input=false", "-detailed-exitcode", "-no-color"],
+            ),
+            (
+                "apply",
+                lazy_fixture("tf_15cmd"),
+                ["-input=false", "-no-color", "-auto-approve"],
+            ),
+            (
+                "destroy",
+                lazy_fixture("tf_15cmd"),
+                ["-input=false", "-no-color", "-auto-approve"],
+            ),
         ],
     )
-    def test_run(self, tf_cmd: str, method: callable):
+    def test_run(self, tf_cmd: str, method: callable, args: list):
         with mock.patch(
             "tfworker.commands.terraform.pipe_exec",
             side_effect=mock_pipe_exec,
@@ -92,6 +166,10 @@ class TestTerraformCommand:
                 method,
             )
             mocked.assert_called_once()
+            call_as_string = str(mocked.mock_calls.pop())
+            assert method in call_as_string
+            for arg in args:
+                assert arg in call_as_string
 
     @pytest.mark.parametrize(
         "stdout, major, minor, expected_exception",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,6 +171,20 @@ def tf_Xcmd(rootc):
 
 
 @pytest.fixture
+def tf_15cmd(rootc):
+    return tfworker.commands.terraform.TerraformCommand(
+        rootc, deployment="test-0001", tf_version=(15, 0)
+    )
+
+
+@pytest.fixture
+def tf_14cmd(rootc):
+    return tfworker.commands.terraform.TerraformCommand(
+        rootc, deployment="test-0001", tf_version=(14, 5)
+    )
+
+
+@pytest.fixture
 def tf_13cmd(rootc):
     return tfworker.commands.terraform.TerraformCommand(
         rootc, deployment="test-0001", tf_version=(13, 5)

--- a/tests/fixtures/definitions/test_a/versions.tf
+++ b/tests/fixtures/definitions/test_a/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.51.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 2.1.2"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/tests/fixtures/gcp_test_config.yaml
+++ b/tests/fixtures/gcp_test_config.yaml
@@ -16,14 +16,14 @@ terraform:
         region: {{ gcp_region }}
 
     'null':
-        vars:
-          version: 2.2.2
+      vars:
+        version: 2.2.2
 
     vault:
       vars:
         version: 3.38.0
         region: {{ gcp_region }}
- 
+
   terraform_vars:
     vpc_cidr: 10.0.0.0/16
     region: {{ gcp_region }}
@@ -42,7 +42,7 @@ terraform:
         list:
           - x
           - y
-          - z 
+          - z
   definitions:
     test:
       path: /definitions/test_a

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -16,14 +16,14 @@ terraform:
         region: {{ aws_region }}
 
     'null':
-        vars:
-          version: 2.2.2
+      vars:
+        version: 2.2.2
 
     vault:
       vars:
         version: 3.38.0
         region: {{ aws_region }}
- 
+
   terraform_vars:
     vpc_cidr: 10.0.0.0/16
     region: {{ aws_region }}
@@ -42,7 +42,7 @@ terraform:
         list:
           - x
           - y
-          - z 
+          - z
   definitions:
     test:
       path: /definitions/test_a

--- a/tests/providers/test_aws.py
+++ b/tests/providers/test_aws.py
@@ -16,7 +16,6 @@
 def test_aws_hcl(basec):
     render = basec.providers["aws"].hcl()
     expected_render = """provider "aws" {
-  version = "2.63"
   region = "us-west-2"
 }"""
     assert render == expected_render

--- a/tests/providers/test_google.py
+++ b/tests/providers/test_google.py
@@ -16,7 +16,6 @@
 def test_google_hcl(basec):
     render = basec.providers["google"].hcl()
     expected_render = """provider "google" {
-  version = "~> 3.39"
   region = "us-west-2"
   credentials = file("/home/test/test-creds.json")
 }"""

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -47,14 +47,14 @@ deployment = "test-0001"
 
 class TestDefinitions:
     @pytest.mark.parametrize(
-        "tf_version, expected_tf_block",
+        "tf_version, expected_tf_block, expected_providers",
         [
-            (14, EXPECTED_TF_BLOCK),
-            (13, EXPECTED_TF_BLOCK),
-            (12, EXPECTED_TF_BLOCK),
+            (14, EXPECTED_TF_BLOCK, ["google", "null"]),
+            (13, EXPECTED_TF_BLOCK, ["google", "null"]),
+            (12, EXPECTED_TF_BLOCK, ["aws", "google", "google_beta", "null", "vault"]),
         ],
     )
-    def test_prep(self, basec, tf_version, expected_tf_block):
+    def test_prep(self, basec, tf_version, expected_tf_block, expected_providers):
         definition = basec.definitions["test"]
         definition._tf_version_major = tf_version
         definition.prep(basec.backend)
@@ -64,7 +64,10 @@ class TestDefinitions:
             assert EXPECTED_TEST_BLOCK in reader.read()
         assert os.path.isfile(basec.temp_dir + "/definitions/test/terraform.tf")
         with open(basec.temp_dir + "/definitions/test/terraform.tf", "r") as reader:
-            assert expected_tf_block in reader.read()
+            tf_data = reader.read()
+            assert expected_tf_block in tf_data
+            for ep in expected_providers:
+                assert f'provider "{ep}" {{' in tf_data
         assert os.path.isfile(basec.temp_dir + "/definitions/test/worker.auto.tfvars")
         with open(
             basec.temp_dir + "/definitions/test/worker.auto.tfvars", "r"

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -49,6 +49,7 @@ class TestDefinitions:
     @pytest.mark.parametrize(
         "tf_version, expected_tf_block, expected_providers",
         [
+            (15, EXPECTED_TF_BLOCK, ["google", "null"]),
             (14, EXPECTED_TF_BLOCK, ["google", "null"]),
             (13, EXPECTED_TF_BLOCK, ["google", "null"]),
             (12, EXPECTED_TF_BLOCK, ["aws", "google", "google_beta", "null", "vault"]),

--- a/tfworker/commands/base.py
+++ b/tfworker/commands/base.py
@@ -49,7 +49,7 @@ class BaseCommand:
         rootc.clean = kwargs.get("clean", True)
 
         self._providers = ProvidersCollection(
-            rootc.providers_odict, self._authenticators
+            rootc.providers_odict, self._authenticators, tf_version_major
         )
         self._definitions = DefinitionsCollection(
             rootc.definitions_odict,

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -197,6 +197,8 @@ class TerraformCommand(BaseCommand):
                 "apply": "-input=false -no-color -auto-approve",
                 "destroy": "-input=false -no-color -force",
             }
+            if self._tf_version_major >= 15:
+                params["destroy"] = "-input=false -no-color -auto-approve"
         else:
             params = {
                 "init": "-input=false -no-color",

--- a/tfworker/definitions.py
+++ b/tfworker/definitions.py
@@ -15,7 +15,7 @@
 import collections
 import copy
 import json
-import os
+from pathlib import Path, PurePath
 from typing import OrderedDict
 
 import click
@@ -88,8 +88,8 @@ class Definition:
         """ Extract only the providers used by a definition """
         result = set(self._providers.keys())
         if self._tf_version_major >= 13:
-            version_path = os.path.join(self._target, "versions.tf")
-            if os.path.exists(version_path):
+            version_path = PurePath(self._target) / "versions.tf"
+            if Path(version_path).exists():
                 with open(version_path, "r") as reader:
                     vinfo = hcl2.load(reader)
                     tf_element = vinfo.get("terraform", [None]).pop()

--- a/tfworker/definitions.py
+++ b/tfworker/definitions.py
@@ -23,7 +23,7 @@ from tfworker.util.copier import CopyFactory
 
 TERRAFORM_TPL = """\
 terraform {{
-{0}{1}
+{0}
 }}
 """
 
@@ -121,16 +121,7 @@ class Definition:
         remotes = list(map(lambda x: x.split(".")[0], self._remote_vars.values()))
         with open(f"{target}/terraform.tf", "w+") as tffile:
             tffile.write(f"{self._providers.hcl(self._provider_excludes)}\n\n")
-            required_providers = ""
-            if self._tf_version_major <= 12:
-                if False:  # self._providers.has_required_providers:
-                    required_providers = f"\n\n{self._providers.required_providers()}"
-            tffile.write(
-                TERRAFORM_TPL.format(
-                    f"{backend.hcl(self.tag)}",
-                    required_providers,
-                )
-            )
+            tffile.write(TERRAFORM_TPL.format(f"{backend.hcl(self.tag)}"))
             tffile.write(backend.data_hcl(remotes))
 
         # Create the variable definitions

--- a/tfworker/definitions.py
+++ b/tfworker/definitions.py
@@ -60,6 +60,8 @@ class Definition:
             body.get("terraform_vars", collections.OrderedDict()), global_terraform_vars
         )
 
+        self._provider_includes = body.get("provider_includes", [])
+
         self._deployment = deployment
         self._repository_path = repository_path
         self._providers = providers
@@ -118,7 +120,7 @@ class Definition:
         # create remote data sources, and required providers
         remotes = list(map(lambda x: x.split(".")[0], self._remote_vars.values()))
         with open(f"{target}/terraform.tf", "w+") as tffile:
-            tffile.write(f"{self._providers.hcl()}\n\n")
+            tffile.write(f"{self._providers.hcl(self._provider_includes)}\n\n")
             required_providers = ""
             if self._tf_version_major <= 12:
                 if False:  # self._providers.has_required_providers:

--- a/tfworker/definitions.py
+++ b/tfworker/definitions.py
@@ -89,7 +89,7 @@ class Definition:
         result = set(self._providers.keys())
         if self._tf_version_major >= 13:
             version_path = os.path.join(self._target, "versions.tf")
-            if os.path.exists(version_path) and os.path.isfile(version_path):
+            if os.path.exists(version_path):
                 with open(version_path, "r") as reader:
                     vinfo = hcl2.load(reader)
                     tf_element = vinfo.get("terraform", [None]).pop()

--- a/tfworker/definitions.py
+++ b/tfworker/definitions.py
@@ -60,7 +60,7 @@ class Definition:
             body.get("terraform_vars", collections.OrderedDict()), global_terraform_vars
         )
 
-        self._provider_includes = body.get("provider_includes", [])
+        self._provider_excludes = body.get("provider_excludes", [])
 
         self._deployment = deployment
         self._repository_path = repository_path
@@ -120,7 +120,7 @@ class Definition:
         # create remote data sources, and required providers
         remotes = list(map(lambda x: x.split(".")[0], self._remote_vars.values()))
         with open(f"{target}/terraform.tf", "w+") as tffile:
-            tffile.write(f"{self._providers.hcl(self._provider_includes)}\n\n")
+            tffile.write(f"{self._providers.hcl(self._provider_excludes)}\n\n")
             required_providers = ""
             if self._tf_version_major <= 12:
                 if False:  # self._providers.has_required_providers:

--- a/tfworker/definitions.py
+++ b/tfworker/definitions.py
@@ -120,8 +120,8 @@ class Definition:
         with open(f"{target}/terraform.tf", "w+") as tffile:
             tffile.write(f"{self._providers.hcl()}\n\n")
             required_providers = ""
-            if self._tf_version_major >= 13:
-                if self._providers.has_required_providers:
+            if self._tf_version_major <= 12:
+                if False:  # self._providers.has_required_providers:
                     required_providers = f"\n\n{self._providers.required_providers()}"
             tffile.write(
                 TERRAFORM_TPL.format(

--- a/tfworker/providers/__init__.py
+++ b/tfworker/providers/__init__.py
@@ -49,7 +49,7 @@ class ProvidersCollection(collections.abc.Mapping):
     def __iter__(self):
         return iter(self._providers.values())
 
-    def hcl(self, excludes):
+    def hcl(self, includes):
         return "\n".join(
-            [prov.hcl() for k, prov in self._providers.items() if k not in excludes]
+            [prov.hcl() for k, prov in self._providers.items() if k in includes]
         )

--- a/tfworker/providers/__init__.py
+++ b/tfworker/providers/__init__.py
@@ -58,8 +58,10 @@ class ProvidersCollection(collections.abc.Mapping):
     def has_required_providers(self):
         return len([True for _, prov in self._providers.items() if prov.source]) > 0
 
-    def hcl(self):
-        return "\n".join([prov.hcl() for _, prov in self._providers.items()])
+    def hcl(self, includes):
+        return "\n".join(
+            [prov.hcl() for k, prov in self._providers.items() if k in includes]
+        )
 
     def required_providers(self):
         content = "\n".join(

--- a/tfworker/providers/__init__.py
+++ b/tfworker/providers/__init__.py
@@ -24,11 +24,6 @@ from .helm import HelmProvider  # noqa
 
 ALL = [AWSProvider, GoogleProvider, GoogleBetaProvider, HelmProvider]
 
-REQUIRED_PROVIDERS_TPL = """\
-  required_providers {{
-{0}
-  }}"""
-
 
 class ProvidersCollection(collections.abc.Mapping):
     def __init__(self, providers_odict, authenticators, tf_version_major):
@@ -54,17 +49,7 @@ class ProvidersCollection(collections.abc.Mapping):
     def __iter__(self):
         return iter(self._providers.values())
 
-    @property
-    def has_required_providers(self):
-        return len([True for _, prov in self._providers.items() if prov.source]) > 0
-
     def hcl(self, excludes):
         return "\n".join(
             [prov.hcl() for k, prov in self._providers.items() if k not in excludes]
         )
-
-    def required_providers(self):
-        content = "\n".join(
-            [prov.required() for _, prov in self._providers.items() if prov.source]
-        )
-        return REQUIRED_PROVIDERS_TPL.format(content)

--- a/tfworker/providers/__init__.py
+++ b/tfworker/providers/__init__.py
@@ -49,6 +49,9 @@ class ProvidersCollection(collections.abc.Mapping):
     def __iter__(self):
         return iter(self._providers.values())
 
+    def keys(self):
+        return self._providers.keys()
+
     def hcl(self, includes):
         return "\n".join(
             [prov.hcl() for k, prov in self._providers.items() if k in includes]

--- a/tfworker/providers/__init__.py
+++ b/tfworker/providers/__init__.py
@@ -31,15 +31,17 @@ REQUIRED_PROVIDERS_TPL = """\
 
 
 class ProvidersCollection(collections.abc.Mapping):
-    def __init__(self, providers_odict, rootc):
+    def __init__(self, providers_odict, authenticators, tf_version_major):
         provider_map = dict([(prov.tag, prov) for prov in ALL])
         self._providers = copy.deepcopy(providers_odict)
         for k, v in self._providers.items():
             try:
-                self._providers[k] = provider_map[k](v, rootc)
+                self._providers[k] = provider_map[k](
+                    v, authenticators, tf_version_major
+                )
 
             except KeyError:
-                self._providers[k] = GenericProvider(v, tag=k)
+                self._providers[k] = GenericProvider(v, tf_version_major, tag=k)
 
     def __len__(self):
         return len(self._providers)
@@ -54,10 +56,7 @@ class ProvidersCollection(collections.abc.Mapping):
 
     @property
     def has_required_providers(self):
-        return (
-            len([prov.required() for _, prov in self._providers.items() if prov.source])
-            > 0
-        )
+        return len([True for _, prov in self._providers.items() if prov.source]) > 0
 
     def hcl(self):
         return "\n".join([prov.hcl() for _, prov in self._providers.items()])

--- a/tfworker/providers/__init__.py
+++ b/tfworker/providers/__init__.py
@@ -58,9 +58,9 @@ class ProvidersCollection(collections.abc.Mapping):
     def has_required_providers(self):
         return len([True for _, prov in self._providers.items() if prov.source]) > 0
 
-    def hcl(self, includes):
+    def hcl(self, excludes):
         return "\n".join(
-            [prov.hcl() for k, prov in self._providers.items() if k in includes]
+            [prov.hcl() for k, prov in self._providers.items() if k not in excludes]
         )
 
     def required_providers(self):

--- a/tfworker/providers/aws.py
+++ b/tfworker/providers/aws.py
@@ -18,7 +18,7 @@ from .base import BaseProvider
 class AWSProvider(BaseProvider):
     tag = "aws"
 
-    def __init__(self, body, authenticators, *args, **kwargs):
-        super(AWSProvider, self).__init__(body)
+    def __init__(self, body, authenticators, tf_version_major, **kwargs):
+        super(AWSProvider, self).__init__(body, tf_version_major)
         self._authenticator = authenticators.get(self.tag)
         self.vars = body.get("vars", {})

--- a/tfworker/providers/base.py
+++ b/tfworker/providers/base.py
@@ -16,17 +16,25 @@
 class BaseProvider:
     tag = None
 
-    def __init__(self, body):
+    def __init__(self, body, tf_version_major):
+        self._tf_version_major = tf_version_major
+
         self.vars = body.get("vars", {})
         self.version = self.vars.get("version")
         self.source = body.get("source")
+
+        self._provider_exclusions = ["version"]
 
     def hcl(self):
         result = []
         provider_vars = {}
         try:
             for k, v in self.vars.items():
-                provider_vars[k] = v
+                if self._tf_version_major >= 13:
+                    if k not in self._provider_exclusions:
+                        provider_vars[k] = v
+                else:
+                    provider_vars[k] = v
         except (KeyError, TypeError):
             """No provider vars were set."""
             pass

--- a/tfworker/providers/base.py
+++ b/tfworker/providers/base.py
@@ -23,7 +23,7 @@ class BaseProvider:
         self.version = self.vars.get("version")
         self.source = body.get("source")
 
-        self._provider_exclusions = ["version"]
+        self._field_filter = ["version"]
 
     def hcl(self):
         result = []
@@ -31,7 +31,7 @@ class BaseProvider:
         try:
             for k, v in self.vars.items():
                 if self._tf_version_major >= 13:
-                    if k not in self._provider_exclusions:
+                    if k not in self._field_filter:
                         provider_vars[k] = v
                 else:
                     provider_vars[k] = v

--- a/tfworker/providers/generic.py
+++ b/tfworker/providers/generic.py
@@ -18,9 +18,10 @@ from .base import BaseProvider
 class GenericProvider(BaseProvider):
     tag = "worker-generic"
 
-    def __init__(self, body, **kwargs):
-        super(GenericProvider, self).__init__(body)
+    def __init__(self, body, tf_version_major, **kwargs):
+        super(GenericProvider, self).__init__(body, tf_version_major)
 
+        self._tf_version_major = tf_version_major
         self.tag = kwargs.get("tag", self.tag)
         self.vars = body.get("vars", {})
         self.version = self.vars.get("version")

--- a/tfworker/providers/google.py
+++ b/tfworker/providers/google.py
@@ -18,8 +18,8 @@ from .base import BaseProvider
 class GoogleProvider(BaseProvider):
     tag = "google"
 
-    def __init__(self, body, authenticators, **kwargs):
-        super(GoogleProvider, self).__init__(body)
+    def __init__(self, body, authenticators, tf_version_major, **kwargs):
+        super(GoogleProvider, self).__init__(body, tf_version_major)
 
         self._authenticator = authenticators.get(self.tag)
 

--- a/tfworker/providers/google_beta.py
+++ b/tfworker/providers/google_beta.py
@@ -18,8 +18,8 @@ from .base import BaseProvider
 class GoogleBetaProvider(BaseProvider):
     tag = "google-beta"
 
-    def __init__(self, body, authenticators, **kwargs):
-        super(GoogleBetaProvider, self).__init__(body)
+    def __init__(self, body, authenticators, tf_version_major, **kwargs):
+        super(GoogleBetaProvider, self).__init__(body, tf_version_major)
 
         self._authenticator = authenticators.get("google")
 

--- a/tfworker/providers/helm.py
+++ b/tfworker/providers/helm.py
@@ -31,7 +31,7 @@ class HelmProvider(BaseProvider):
         provider_vars = {}
         try:
             for k, v in self.vars.items():
-                if k not in self._provider_exclusions:
+                if k not in self._field_filter:
                     provider_vars[k] = v
         except (KeyError, TypeError):
             """No provider vars were set."""

--- a/tfworker/providers/helm.py
+++ b/tfworker/providers/helm.py
@@ -31,7 +31,10 @@ class HelmProvider(BaseProvider):
         provider_vars = {}
         try:
             for k, v in self.vars.items():
-                if k not in self._field_filter:
+                if self._tf_version_major >= 13:
+                    if k not in self._field_filter:
+                        provider_vars[k] = v
+                else:
                     provider_vars[k] = v
         except (KeyError, TypeError):
             """No provider vars were set."""

--- a/tfworker/providers/helm.py
+++ b/tfworker/providers/helm.py
@@ -20,8 +20,8 @@ from .base import BaseProvider
 class HelmProvider(BaseProvider):
     tag = "helm"
 
-    def __init__(self, body, authenticators, **kwargs):
-        super(HelmProvider, self).__init__(body)
+    def __init__(self, body, authenticators, tf_version_major, **kwargs):
+        super(HelmProvider, self).__init__(body, tf_version_major)
         self.tag = kwargs.get("tag", self.tag)
         self.vars = body.get("vars", {})
         self.version = body.get("version")
@@ -31,7 +31,8 @@ class HelmProvider(BaseProvider):
         provider_vars = {}
         try:
             for k, v in self.vars.items():
-                provider_vars[k] = v
+                if k not in self._provider_exclusions:
+                    provider_vars[k] = v
         except (KeyError, TypeError):
             """No provider vars were set."""
             pass


### PR DESCRIPTION
This PR is related to the following wiki articles and is concerned with updates that are required to allow the worker to run with terraform 0.14 and 0.15.

https://objectrocket.atlassian.net/wiki/spaces/PT/pages/2454781970/Changes+related+to+support+terraform+0.14.x
AND
https://objectrocket.atlassian.net/wiki/spaces/PT/pages/2454781970/Changes+related+to+support+terraform+0.15.x
